### PR TITLE
fix(tunnel): chunk writes to max IAP frame size

### DIFF
--- a/pkg/tunnel.go
+++ b/pkg/tunnel.go
@@ -108,7 +108,31 @@ func (t *TunnelAdapter) Read(p []byte) (int, error) {
 }
 
 func (t *TunnelAdapter) Write(p []byte) (int, error) {
-	return t.protocol.SendDataFrame(t.conn, p)
+	t.mu.Lock()
+	conn := t.conn
+	t.mu.Unlock()
+
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	totalWritten := 0
+	for len(p) > 0 {
+		chunkSize := SUBPROTOCOL_MAX_DATA_FRAME_SIZE
+		if len(p) < chunkSize {
+			chunkSize = len(p)
+		}
+
+		n, err := t.protocol.SendDataFrame(conn, p[:chunkSize])
+		totalWritten += n
+		if err != nil {
+			return totalWritten, err
+		}
+
+		p = p[chunkSize:]
+	}
+
+	return totalWritten, nil
 }
 
 func (t *TunnelAdapter) Close() error {

--- a/pkg/tunnel_test.go
+++ b/pkg/tunnel_test.go
@@ -141,6 +141,33 @@ func TestTunnelAdapter_Write(t *testing.T) {
 	assert.Equal(t, len(data), n)
 }
 
+func TestTunnelAdapter_WriteLargePayloadIsChunked(t *testing.T) {
+	server := startEchoWebSocketServer(t)
+	defer server.Close()
+
+	wsURL := "ws" + server.URL[len("http"):]
+	conn, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	require.NoError(t, err, "websocket.Dial failed")
+	defer func() {
+		if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
+			t.Errorf("failed to close websocket: %v", err)
+		}
+	}()
+
+	adapter := &TunnelAdapter{
+		conn:     conn,
+		protocol: NewIAPTunnelProtocol(),
+		target:   TunnelTarget{},
+		inbound:  make(chan []byte, 1),
+		closed:   make(chan struct{}),
+	}
+
+	data := bytes.Repeat([]byte("x"), SUBPROTOCOL_MAX_DATA_FRAME_SIZE*2+123)
+	n, err := adapter.Write(data)
+	require.NoError(t, err)
+	assert.Equal(t, len(data), n)
+}
+
 func TestTunnelAdapter_Close(t *testing.T) {
 	server := startEchoWebSocketServer(t)
 	defer server.Close()


### PR DESCRIPTION
# Description
Fix oversized data-frame failures by chunking tunnel writes to the protocol max frame size (16384 bytes).

# Changes
Chunk TunnelAdapter.Write payloads into <= 16KB frames before sending.
